### PR TITLE
Readme and setup formatting issues for pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 django-celery-email-reboot - A Celery-backed Django Email Backend
 ===========================================================================
 
-.. image:: https://img.shields.io/pypi/v/django-celery-email.svg
-    :target: https://pypi.python.org/pypi/django-celery-email
+.. image:: https://img.shields.io/pypi/v/django-celery-email-reboot.svg
+    :target: https://pypi.python.org/pypi/django-celery-email-reboot
 
 A `Django`_ email backend that uses a `Celery`_ queue for out-of-band sending of the messages.
 

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,13 @@
-==========================================================
+===========================================================================
 django-celery-email-reboot - A Celery-backed Django Email Backend
-==========================================================
+===========================================================================
 
 .. image:: https://img.shields.io/pypi/v/django-celery-email.svg
     :target: https://pypi.python.org/pypi/django-celery-email
 
-A `Django`_ email backend that uses a `Celery`_ queue for out-of-band sending
-of the messages.
+A `Django`_ email backend that uses a `Celery`_ queue for out-of-band sending of the messages.
 
-This is a fork of `django_celery_email`_. As this package has gone unmaintained 
-for some time, we have decided to maintain the package in order to maintain 
-compatability with future Django versions, starting with Django 4.x and 5.x.
+This is a fork of `django_celery_email`_. As this package has gone unmaintained for some time, we have decided to maintain the package in order to maintain compatibility with future Django versions, starting with Django 4.x and 5.x.
 
 This new package is available in pypi under the name `django-celery-email-reboot`: https://pypi.org/project/django-celery-email-reboot/
 
@@ -24,21 +21,23 @@ This new package is available in pypi under the name `django-celery-email-reboot
 
     * Python >= 3.9, < 3.14
     * Celery:
+
       * >= 5.2, < 5.6 for Python 3.9 to 3.11
       * >= 5.3, < 5.6 for Python 3.12 and 3.13
+
     * Django:
+
       * >= 3.2, < 4.3 for Python 3.9
       * >= 4.0, < 5.1 for Python 3.10
       * >= 4.1, < 5.3 for Python 3.11
       * >= 4.2, < 5.3 for Python 3.12 and 3.13
 
 Using django-celery-email-reboot
-=========================
+==================================
 
-Install from Pypi using:
-```
-pip install django-celery-email-reboot
-```
+Install from Pypi using::
+
+    pip install django-celery-email-reboot
 
 To enable ``django-celery-email-reboot`` for your project you need to add ``djcelery_email`` to
 ``INSTALLED_APPS``::

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version=about['__version__'],
     description=about['__summary__'],
     long_description=long_description,
+    long_description_content_type='text/x-rst',
     license=about['__license__'],
     url=about['__uri__'],
     author=about['__author__'],


### PR DESCRIPTION
This PR fixes the formatting issues in the README.rst file and sets the long_description_content_type to `text/x-rst`. This is necessary in order to publish the package to pypi

![2025-06-17-105129_866x454_scrot](https://github.com/user-attachments/assets/d6e5d02e-79d3-4a2d-b8f6-5568816e2ed9)
